### PR TITLE
CDK-567: Made logging tests more cluster agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,10 @@ Then type:
 mvn verify -DuseExternalCluster=true
 ```
 
+When running against an external cluster, the integration tests assume that your
+Hadoop configuration files are in `/etc/hadoop/conf`. If you need to specify a
+different directory, use:
+
+```bash
+mvn verify -DuseExternalCluster=true -Dhadoop.conf.dir=/my/hadoop/conf
+```

--- a/logging-webapp/src/test/java/org/kitesdk/examples/logging/webapp/ITLoggingWebapp.java
+++ b/logging-webapp/src/test/java/org/kitesdk/examples/logging/webapp/ITLoggingWebapp.java
@@ -86,12 +86,7 @@ public class ITLoggingWebapp {
     appender.setName("flume");
     appender.setHostname("localhost");
     appender.setPort(41415);
-    // TODO: without this we get "java.lang.IllegalArgumentException: Wrong FS" in Flume
-    if (Cluster.isUsingExternalCluster()) {
-      appender.setDatasetRepositoryUri("repo:hdfs://localhost.localdomain/tmp/data");
-    } else {
-      appender.setDatasetRepositoryUri("repo:hdfs://localhost/tmp/data");
-    }
+    appender.setDatasetRepositoryUri("repo:hdfs:/tmp/data");
     appender.setDatasetName("events");
     appender.activateOptions();
 

--- a/logging/src/test/java/org/kitesdk/examples/logging/ITLogging.java
+++ b/logging/src/test/java/org/kitesdk/examples/logging/ITLogging.java
@@ -71,12 +71,7 @@ public class ITLogging {
     appender.setName("flume");
     appender.setHostname("localhost");
     appender.setPort(41415);
-    // TODO: without this we get "java.lang.IllegalArgumentException: Wrong FS" in Flume
-    if (Cluster.isUsingExternalCluster()) {
-      appender.setDatasetRepositoryUri("repo:hdfs://localhost.localdomain/tmp/data");
-    } else {
-      appender.setDatasetRepositoryUri("repo:hdfs://localhost/tmp/data");
-    }
+    appender.setDatasetRepositoryUri("repo:hdfs:/tmp/data");
     appender.setDatasetName("events");
     appender.activateOptions();
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
   <properties>
     <!-- Keep this updated to the latest Kite release! -->
     <kite-version>0.15.1-SNAPSHOT</kite-version>
+    <hadoop.conf.dir>/etc/hadoop/conf</hadoop.conf.dir>
   </properties>
 
   <build>
@@ -88,5 +89,32 @@
       </snapshots>
     </repository>
   </repositories>
+
+  <profiles>
+    <profile>
+      <id>external-cluster</id>
+      <activation>
+        <property>
+          <name>useExternalCluster</name>
+        </property>
+      </activation>
+      <build>
+        <testResources>
+          <testResource>
+            <directory>${hadoop.conf.dir}</directory>
+            <includes>
+              <include>core-site.xml</include>
+              <include>hdfs-site.xml</include>
+              <include>yarn-site.xml</include>
+              <include>mapred-site.xml</include>
+            </includes>
+          </testResource>
+          <testResource>
+            <directory>src/test/resources</directory>
+          </testResource>
+        </testResources>
+      </build>
+    </profile>
+  </profiles>
 
 </project>


### PR DESCRIPTION
- Added a maven profile for running against an external cluster
- Added /etc/hadoop/conf to the test resources for the profile
- Updated the README
